### PR TITLE
Change Draggable component keys and ids

### DIFF
--- a/src/components/Content/Content.js
+++ b/src/components/Content/Content.js
@@ -67,7 +67,7 @@ class Content extends Component {
                         {provided => (
                           <div ref={provided.innerRef}>
                             {this.props.items.map((item, index) => (
-                              <Draggable key={index} draggableId={index} index={index}>
+                              <Draggable key={item.id} draggableId={item.id} index={index}>
                                 {provided => (
                                   <div
                                     ref={provided.innerRef}


### PR DESCRIPTION
This fixes the following error: 
`Error: Invariant failed: Draggable requires a draggableId`

... and also removes the use of array index as element key, which is considered not the best practice.